### PR TITLE
fix: copy nvidia-modeset to /usr/lib/modprobe.d

### DIFF
--- a/kmods/nvidia/scripts/install/01-install.sh
+++ b/kmods/nvidia/scripts/install/01-install.sh
@@ -25,4 +25,5 @@ rpm-ostree install \
     nvidia-container-toolkit \
     /tmp/akmods/rpms/kmod-nvidia-${KERNEL_VERSION}-${NVIDIA_AKMOD_VERSION}.fc${RELEASE}.rpm
 
+cp /etc/modprobe.d/nvidia-modeset.conf /usr/lib/modprobe.d/nvidia-modeset.conf
 sed -i 's@omit_drivers@force_drivers@g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf


### PR DESCRIPTION
So the parameters are loaded early during boot