### PR TITLE
fix(nvidia): handle 610 driver-common package split

### DIFF
--- a/kmods/nvidia/scripts/install/01-install.sh
+++ b/kmods/nvidia/scripts/install/01-install.sh
@@ -27,6 +27,7 @@ COMMON_PKGS=(
     libnvidia-fbc
     libva-nvidia-driver
     nvidia-driver
+    nvidia-driver-common
     nvidia-modprobe
     nvidia-persistenced
     nvidia-driver-cuda
@@ -40,10 +41,7 @@ ARCH_PKGS=()
 # Add architecture-specific packages based on detected architecture
 if [ "$ARCH" = "x86_64" ]; then
     ARCH_PKGS=(
-        libnvidia-ml.i686
         mesa-vulkan-drivers.i686
-        nvidia-driver-cuda-libs.i686
-        nvidia-driver-libs.i686
         egl-wayland2.x86_64
         egl-wayland2.i686
     )


### PR DESCRIPTION
## Summary
- nvidia-driver 610 consolidates `libnvidia-cfg`, `libnvidia-gpucomp`, and `libnvidia-ml` into a new `nvidia-driver-common` package
- Add `nvidia-driver-common` to common packages
- Replace `libnvidia-ml.i686` with `nvidia-driver-common.i686` for x86_64

Ref: https://github.com/ublue-os/akmods/pull/535

## Test plan
- [ ] Build nvidia kmod image on x86_64 with nvidia-driver 610+
- [ ] Verify `nvidia-driver-common` and `nvidia-driver-common.i686` are installed